### PR TITLE
Add correct Discord link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MacForge is an open-source plugin manager for macOS. It lets you discover, install and manage plugins to improve the user experience of macOS without the need for manually cloning/building or copying files.
 
-[![Discord](https://discordapp.com/api/guilds/608740492561219617/widget.png?style=banner2)](https://discordapp.com/channels/608740492561219617/608740492640911378)
+[![Discord](https://discordapp.com/api/guilds/608740492561219617/widget.png?style=banner2)](https://discord.com/invite/zjCHuew)
 
 ![Preview](web/preview.png)
 


### PR DESCRIPTION
I tried to join the Discord channel from the link shared in the README but to no avail. I found the right link within MacForge but figured it might be a good idea to propose a change to the link here as well so others can find it. I'm not sure if this is the link you want to use, but it's the link that successfully brought me to the correct channel; feel free to change that if needed.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
